### PR TITLE
Update McityToolbarVuetify1.5.vue

### DIFF
--- a/components/McityToolbarVuetify1.5.vue
+++ b/components/McityToolbarVuetify1.5.vue
@@ -236,7 +236,6 @@ export default {
       return tileText === "FOR MEMBERS" ? "color:white" : "";
     },
     getCssClassForCategory(tileText, hover) {
-      console.log(tileText, hover)
       return tileText === "FOR MEMBERS" ? (hover ? "bg-members-hover" : "bg-members") : "";
     },
     getHelp () {


### PR DESCRIPTION
removed console.logs which logged the state of the menu options at each mouseOver
<img width="1920" alt="Screenshot 2024-01-24 at 9 51 47 AM" src="https://github.com/mcity/Mcity-vue-shared/assets/55931783/2ed32815-528f-4efe-a683-d21673bbd011">
